### PR TITLE
Fix ShoppingCartLayout bug

### DIFF
--- a/app/src/main/java/com/avenger/avengerapp/presentation/ui/views/ShoppingCartLayout.kt
+++ b/app/src/main/java/com/avenger/avengerapp/presentation/ui/views/ShoppingCartLayout.kt
@@ -1,12 +1,14 @@
 package com.avenger.avengerapp.presentation.ui.views
 
 import android.content.Context
+import android.support.constraint.ConstraintLayout
 import android.support.v7.widget.LinearLayoutCompat
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
+import android.widget.FrameLayout
 import com.avenger.avengerapp.R
 import com.avenger.avengerapp.domain.models.OrderItem
 import com.avenger.avengerapp.presentation.ui.adapters.ShoppingCartAdapter
@@ -17,7 +19,7 @@ import kotlinx.android.synthetic.main.shopping_cart_layout.view.*
 /**
  * Created by RobGThai on 9/21/16.
  */
-class ShoppingCartLayout: LinearLayoutCompat {
+class ShoppingCartLayout: ConstraintLayout {
 
     val swipeManager: RecyclerViewSwipeManager = RecyclerViewSwipeManager()
 

--- a/app/src/main/res/layout/shopping_cart_layout.xml
+++ b/app/src/main/res/layout/shopping_cart_layout.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
+<merge
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    tools:parentTag="android.support.design.widget.CoordinatorLayout">
 
     <LinearLayout
         android:id="@+id/header"
         android:orientation="horizontal"
-        android:layout_width="752dp"
+        android:layout_width="0dp"
         android:layout_height="100dp"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
@@ -37,7 +38,7 @@
     <android.support.v7.widget.RecyclerView
         android:id="@+id/rv"
         android:layout_width="0dp"
-        android:layout_height="671dp"
+        android:layout_height="0dp"
         android:clipToPadding="false"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
@@ -48,15 +49,16 @@
     <LinearLayout
         android:id="@+id/footer"
         android:orientation="horizontal"
-        android:layout_width="752dp"
+        android:layout_width="0dp"
         android:layout_height="100dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
         >
+
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Footer" />
     </LinearLayout>
-</android.support.constraint.ConstraintLayout>
+</merge>


### PR DESCRIPTION
Hi. This PR fixes the issue reported to [issue #312](https://github.com/h6ah4i/android-advancedrecyclerview/issues/312) of Advanced RecyclerView.

I noticed that you have made a mistake when creating custom view; the `ShoppingCartLayout`'s parent class is **`LinearLayoutCompat`** but layout XML root element is  **`ConstraintLayout`**. 
